### PR TITLE
Reset words table in test fixture

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,8 +5,9 @@ def _fake_db(tmp_path):
     os.makedirs("data", exist_ok=True)
     con = sqlite3.connect("data/words_index.sqlite")
     cur = con.cursor()
+    cur.execute("DROP TABLE IF EXISTS words")
     cur.executescript("""
-        CREATE TABLE IF NOT EXISTS words(
+        CREATE TABLE words(
             word TEXT PRIMARY KEY,
             pron TEXT NOT NULL,
             syls INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- drop the words table in the search test fixture before recreating it to prevent leftover rows

## Testing
- pytest tests/test_search.py

------
https://chatgpt.com/codex/tasks/task_e_68e44090471883229687b32c16393a8c