### PR TITLE
Normalize fallback lookups for punctuation

### DIFF
--- a/rhyme_core/fallback.py
+++ b/rhyme_core/fallback.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, Optional, Tuple
 
-from .normalize import normalize_text
+from .normalize import normalize_word
 
 # Minimal pronunciation dictionary covering smoke tests and unit tests.
 # Phones are taken from CMUdict and simplified (stress digits retained).
@@ -39,17 +39,20 @@ FALLBACK_WORDS = tuple(sorted(_FALLBACK_PRONS.keys()))
 
 
 def has_fallback(word: str) -> bool:
-    return normalize_text(word) in _FALLBACK_PRONS
+    return normalize_word(word) in _FALLBACK_PRONS
 
 
 def get_fallback_pron(word: str) -> Optional[Tuple[str, ...]]:
-    return _FALLBACK_PRONS.get(normalize_text(word))
+    key = normalize_word(word)
+    if not key:
+        return None
+    return _FALLBACK_PRONS.get(key)
 
 
-def iter_fallback_items(exclude: Iterable[str] = ()):
-    excluded = {normalize_text(e) for e in exclude}
+def iter_fallback_items(exclude: Iterable[str] = ()):  # noqa: D417 - simple generator
+    excluded = {normalize_word(e) for e in exclude}
     for word, pron in _FALLBACK_PRONS.items():
-        if word in excluded:
+        if not word or normalize_word(word) in excluded:
             continue
         yield word, pron
 

--- a/rhyme_core/normalize.py
+++ b/rhyme_core/normalize.py
@@ -24,6 +24,7 @@ _DASHES = {
 
 _WHITESPACE_RE = re.compile(r"\s+")
 _DASH_RE = re.compile(r"[-]+")
+_WORD_CLEAN_RE = re.compile(r"[^a-z0-9\-\s']+")
 
 
 def _strip_accents(text: str) -> str:
@@ -49,4 +50,15 @@ def normalize_text(text: str) -> str:
 def normalize_texts(items: Iterable[str]) -> List[str]:
     return [normalize_text(item) for item in items]
 
-__all__ = ["normalize_text", "normalize_texts"]
+
+def normalize_word(text: str) -> str:
+    """Normalize text for dictionary lookups by stripping punctuation and spaces."""
+    normalized = normalize_text(text)
+    if not normalized:
+        return ""
+    cleaned = _WORD_CLEAN_RE.sub("", normalized)
+    cleaned = cleaned.replace("-", " ")
+    cleaned = cleaned.replace(" ", "")
+    return cleaned.strip()
+
+__all__ = ["normalize_text", "normalize_texts", "normalize_word"]

--- a/rhyme_core/search.py
+++ b/rhyme_core/search.py
@@ -46,7 +46,7 @@ from wordfreq import zipf_frequency  # rarity
 
 from config import FLAGS
 
-from rhyme_core.normalize import normalize_text
+from rhyme_core.normalize import normalize_text, normalize_word
 from rhyme_core.prosody import syllable_count, stress_pattern_str  # type: ignore
 
 from .fallback import get_fallback_pron, iter_fallback_items
@@ -80,15 +80,12 @@ LOGGER = logging.getLogger(__name__)
 # ----------------------------------------------------------------------------
 _VOWELS = {"AA","AE","AH","AO","AW","AY","EH","ER","EY","IH","IY","OW","OY","UH","UW"}
 _STRIP_STRESS = re.compile(r"(\d)")
-_WORD_CLEAN = re.compile(r"[^a-z0-9\\-\\s']+")
 _TOKEN_SPLIT = re.compile(r"[\\s\\-]+")
 
 
 def _clean_word(w: str) -> str:
     """Normalize text and keep alphanumerics for key lookup."""
-    base = normalize_text(w)
-    cleaned = _WORD_CLEAN.sub("", base)
-    return cleaned.replace(" ", "").strip()
+    return normalize_word(w)
 
 def _base_phone(p: str) -> str:
     """Remove stress digits from a CMU phone (e.g., AY1 -> AY)."""

--- a/tests/test_fallbacks.py
+++ b/tests/test_fallbacks.py
@@ -36,3 +36,9 @@ def test_symmetry_like_pair(monkeypatch: pytest.MonkeyPatch):
     rhyme_rows = search.search_word("rhyme", max_results=10)
     assert any(r["word"] == "rhyme" for r in time_rows)
     assert any(r["word"] == "time" for r in rhyme_rows)
+
+
+def test_fallback_normalizes_punctuation(monkeypatch: pytest.MonkeyPatch):
+    search = _reload_search(monkeypatch)
+    rows = search.search_word("hat!!!", max_results=10)
+    assert any(r["word"] == "cat" for r in rows)


### PR DESCRIPTION
## Summary
- add a shared `normalize_word` helper so lookup keys strip punctuation and spaces
- update fallback helpers and search to use the shared normalizer for consistent behavior
- cover punctuation handling with a regression test for the fallback search path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4691334408322a190c0197560138b