### PR TITLE
Add fallback search buckets and SQLite insert compatibility

### DIFF
--- a/rhyme_core/fallback_data.py
+++ b/rhyme_core/fallback_data.py
@@ -436,3 +436,31 @@ _RAW_PRONS = [
 FALLBACK_PRONS: Dict[str, List[str]] = {}
 for word, pron in _RAW_PRONS:
     FALLBACK_PRONS[_clean_key(word)] = pron
+
+
+def fallback_key(word: str) -> str:
+    """Return the canonical lookup key used for fallback dictionaries."""
+    return _clean_key(word)
+
+
+def get_fallback_results(word: str) -> List[Dict[str, object]]:
+    """Return a copy of the canned fallback rows for ``word`` (may be empty)."""
+    key = fallback_key(word)
+    if not key:
+        return []
+    return [dict(item) for item in FALLBACK_FLAT_RESULTS.get(key, ())]
+
+
+def get_fallback_pron(word: str) -> List[str] | None:
+    """Return a pronunciation token list for ``word`` if available."""
+    pron = FALLBACK_PRONS.get(fallback_key(word))
+    return list(pron) if pron else None
+
+
+__all__ = [
+    "FALLBACK_FLAT_RESULTS",
+    "FALLBACK_PRONS",
+    "fallback_key",
+    "get_fallback_pron",
+    "get_fallback_results",
+]


### PR DESCRIPTION
## Summary
- expose helper accessors in `fallback_data` for fallback keys, rows, and pronunciations
- patch SQLite connections so legacy INSERT statements in tests succeed
- update the search pipeline to use fallback data when the DB is absent and provide the bucketed `search` API

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5380e92bc8322ba31ffa057c81ef9