### PR TITLE
Backfill tail-key columns with shared helpers

### DIFF
--- a/rhyme_core/index_builder.py
+++ b/rhyme_core/index_builder.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 import sqlite3, os, json
-from .phonetics import parse_cmu_line, syllable_count, key_k1, key_k2
+from .phonetics import (
+    parse_cmu_line,
+    syllable_count,
+    key_k1,
+    key_k2,
+    tail_keys,
+)
 
 def build_words_index(cmu_path: str, sqlite_path: str):
     os.makedirs(os.path.dirname(sqlite_path), exist_ok=True)
@@ -13,10 +19,16 @@ def build_words_index(cmu_path: str, sqlite_path: str):
             pron TEXT NOT NULL,
             syls INTEGER NOT NULL,
             k1   TEXT NOT NULL,
-            k2   TEXT NOT NULL
+            k2   TEXT NOT NULL,
+            rime_key  TEXT NOT NULL,
+            vowel_key TEXT NOT NULL,
+            coda_key  TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_k1 ON words(k1);
         CREATE INDEX IF NOT EXISTS idx_k2 ON words(k2);
+        CREATE INDEX IF NOT EXISTS idx_rime_key ON words(rime_key);
+        CREATE INDEX IF NOT EXISTS idx_vowel_key ON words(vowel_key);
+        CREATE INDEX IF NOT EXISTS idx_coda_key ON words(coda_key);
     """)
     batch=[]
     with open(cmu_path, "r", encoding="utf8", errors="ignore") as f:
@@ -28,10 +40,17 @@ def build_words_index(cmu_path: str, sqlite_path: str):
             syls = syllable_count(phones)
             k1 = json.dumps(tuple(key_k1(phones)))
             k2 = json.dumps(tuple(key_k2(phones)))
-            batch.append((word, json.dumps(phones), syls, k1, k2))
+            vowel, coda, rime = tail_keys(phones)
+            batch.append((word, json.dumps(phones), syls, k1, k2, rime, vowel, coda))
             if len(batch) >= 2000:
-                cur.executemany("INSERT OR REPLACE INTO words VALUES(?,?,?,?,?)", batch)
+                cur.executemany(
+                    "INSERT OR REPLACE INTO words VALUES(?,?,?,?,?,?,?,?)",
+                    batch,
+                )
                 batch.clear()
     if batch:
-        cur.executemany("INSERT OR REPLACE INTO words VALUES(?,?,?,?,?)", batch)
+        cur.executemany(
+            "INSERT OR REPLACE INTO words VALUES(?,?,?,?,?,?,?,?)",
+            batch,
+        )
     con.commit(); con.close()

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -1,0 +1,18 @@
+from rhyme_core.phonetics import parse_pron_field, tail_keys
+
+
+def test_parse_pron_field_accepts_json_string():
+    pron = '["T","AE1","K"]'
+    toks = parse_pron_field(pron)
+    assert toks == ["T", "AE1", "K"]
+
+
+def test_parse_pron_field_accepts_whitespace_string():
+    pron = "W IH1 N D OW0"
+    toks = parse_pron_field(pron)
+    assert toks == ["W", "IH1", "N", "D", "OW0"]
+
+
+def test_tail_keys_with_and_without_coda():
+    assert tail_keys(["T", "AE1", "K"]) == ("AE1", "K", "AE1-K")
+    assert tail_keys(["W", "OW1"]) == ("OW1", "", "OW1")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,5 @@
 import os, sqlite3, json
-from rhyme_core.search import search_word
+from rhyme_core.search import search_word, _derive_tail_keys_from_pron
 
 def _fake_db(tmp_path):
     os.makedirs("data", exist_ok=True)
@@ -21,10 +21,17 @@ def _fake_db(tmp_path):
     # minimal fake entry set
     w = "window"
     pron = json.dumps(["W","IH1","N","D","OW0"])
-    cur.execute("INSERT OR REPLACE INTO words VALUES(?,?,?,?,?)",
-                (w, pron, 2, json.dumps(["IH1","N","D","OW0"]), json.dumps(["IH1","N","D","OW0"])))
-    cur.execute("INSERT OR REPLACE INTO words VALUES(?,?,?,?,?)",
-                ("thin-blow", pron, 2, json.dumps(["IH1","N","D","OW0"]), json.dumps(["IH1","N","D","OW0"])))
+    vowel_key, coda_key, rime_key = _derive_tail_keys_from_pron(pron)
+    payload = (w, pron, 2,
+               json.dumps(["IH1","N","D","OW0"]),
+               json.dumps(["IH1","N","D","OW0"]),
+               rime_key, vowel_key, coda_key)
+    cur.execute("INSERT OR REPLACE INTO words VALUES(?,?,?,?,?,?,?,?)", payload)
+    cur.execute("INSERT OR REPLACE INTO words VALUES(?,?,?,?,?,?,?,?)",
+                ("thin-blow", pron, 2,
+                 json.dumps(["IH1","N","D","OW0"]),
+                 json.dumps(["IH1","N","D","OW0"]),
+                 rime_key, vowel_key, coda_key))
     con.commit(); con.close()
 
 def test_search_smoke(tmp_path):


### PR DESCRIPTION
## Summary
- add shared pronunciation parsing and tail key helpers so ingestion, search, and migrations compute keys identically
- update the words index builder and search paths to reuse the shared helpers
- refresh the migration scripts to backfill the new columns and add coverage for the helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54a42551c8322a217a746c3346ccb